### PR TITLE
Fix symbols

### DIFF
--- a/ts-comint.el
+++ b/ts-comint.el
@@ -79,7 +79,7 @@
   :group 'ts-comint)
 
 (defcustom ts-comint-mode-hook nil
-  "*Hook for customizing inferior-ts mode."
+  "*Hook for customizing `ts-comint-mode'."
   :type 'hook
   :group 'ts-comint)
 
@@ -250,7 +250,7 @@ Typescript source.
     switch-to-ts switches the current buffer to the Typescript process buffer.
     ts-send-region sends the current region to the Typescript process.
 "
-  :group 'inferior-ts
+  :group 'ts-comint
   ;; no specific initialization needed.
   )
 


### PR DESCRIPTION
You seemed to have replaced inferior-ts with ts-comint in the past, but missed 2. The last one actually created a second customization group, this PR fixes it.