### PR TITLE
Make cmd argument optional, since its handling is optional

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,3 +59,15 @@ interpreter inside of typescript-mode.
             (local-set-key (kbd "C-c C-b") 'ts-send-buffer-and-go)
             (local-set-key (kbd "C-c l") 'ts-load-file-and-go)))
 #+END_SRC
+
+* ~repl-toggle~ compatibility
+
+~ts-comint~ is [[https://github.com/tomterl/repl-toggle][~repl-toggle~]] compatible. To configure,  add ~run-ts~
+for ~typescript-mode~ to ~rtog/mode-repl-alist~ like so:
+
+#+BEGIN_SRC elisp
+;; when configuring all repl toggle mapping
+(setq rtog/mode-repl-alist '((typescript-mode . run-ts)))
+;; or later
+(push '(typescript-mode . run-ts) rtog/mode-repl-alist)
+#+END_SRC

--- a/ts-comint.el
+++ b/ts-comint.el
@@ -101,7 +101,7 @@
           "\"\n"))
 
 ;;;###autoload
-(defun run-ts (cmd &optional dont-switch-p)
+(defun run-ts (&optional cmd dont-switch-p)
   "Run an inferior Typescript process, via buffer `*Typescript*'.
 If there is a process already running in `*Typescript*', switch
 to that buffer.  With argument `CMD', allows you to edit the


### PR DESCRIPTION
Since `run-ts` can be run without a command, the argument should be optional. A byproduct of this change also is that it makes the command compatible with [repl-toggle](https://github.com/tomterl/repl-toggle) in the form of `(typescript-mode . run-ts)`.